### PR TITLE
Update database test workflow

### DIFF
--- a/.github/workflows/db.yml
+++ b/.github/workflows/db.yml
@@ -16,9 +16,11 @@ jobs:
     - name: Check out the code
       uses: actions/checkout@v2
     - name: Apply all migrations on empty DB
-      run: |
-        docker compose up -d database
-        docker compose run --rm flyway migrate
+      run: docker compose up -d
+    - name: Wait 5 minutes
+      run: sleep 300
+    - name: Print the flyway logs, if needed
+      run: docker compose logs flyway
     - name: Remove the docker containers
       run: |
         docker compose stop

--- a/.github/workflows/db.yml
+++ b/.github/workflows/db.yml
@@ -16,12 +16,7 @@ jobs:
     - name: Check out the code
       uses: actions/checkout@v2
     - name: Apply all migrations on empty DB
-      run: docker compose up -d
-    - name: Wait 5 minutes
-      run: sleep 300
-    - name: Print the flyway logs, if needed
+      run: docker compose up --exit-code-from flyway
+    - name: Print the flyway logs, if needed later
       run: docker compose logs flyway
-    - name: Remove the docker containers
-      run: |
-        docker compose stop
-        docker compose rm -fv
+      if: always()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,9 @@ services:
       - ./sql/migrations:/flyway/sql
       - ./sql:/flyway/conf
     depends_on:
-      - database
+      database:
+        condition: service_healthy
+
   database:
     image: postgres:14
     restart: always
@@ -15,11 +17,18 @@ services:
       ./sql/db.env
     ports:
       - 5432:5432
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+
   redis_cache:
     image: redis:6
     restart: always
     ports:
       - 6379:6379
+
   web:
     build: .
     ports:


### PR DESCRIPTION
Change the docker compose file to include a service health check on the database before flyway runs.  This removes the need for `sleep whatever` statements to wait on that.

Change the workflow to use the exit code from the flyway service to determine success of the migration test.  Needed because if flyway fails, the workflow still succeeds and that's a problem.  Also added an `if: always()` to always print the flyway logs so as not to have to look through the entire app's logs.